### PR TITLE
🔖 release: 1.4.0

### DIFF
--- a/docs/changelog/1.4.0/CHANGELOG.md
+++ b/docs/changelog/1.4.0/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 - Add CLAUDE.md with project guidance and architecture documentation (4f5b237)
+- Add mango-assistant project to portfolio (83eecc8)
+- Add Docucofi project page and update project details component to support GitHub links (e73116a)
+- Rename ScTools to Redna-Models, update project metadata, and migrate documentation links (864d964)
 
 ### Changed
 - Upgrade Tailwind CSS to v4 (30f4920)

--- a/messages/en.json
+++ b/messages/en.json
@@ -69,9 +69,24 @@
     "projectBtn": "See More",
     "scTools": {
       "seeMore": "/en/sctools"
+    },
+    "mangoAssistant": {
+      "seeMore": "/en/mango-assistant"
     }
   },
   "ProjectDetails": {
+    "mangoAssistant": {
+      "title": "Mango",
+      "desc": "A keyboard-driven TUI for running your shell command sequences — no more copy-pasting the same commands. Define macros (named sequences of shell commands) grouped by category, pick one from the TUI, and it runs with real-time output streaming. Macros that need input show a prompt dialog before running.",
+      "pypi": {
+        "label": "PyPI",
+        "link": "https://pypi.org/project/mango-tui/"
+      },
+      "goIt": {
+        "label": "GitHub",
+        "link": "https://github.com/juanleon8581/mango-assistant"
+      }
+    },
     "scTools": {
       "title": "ScTools",
       "desc": "SCTools is a Chrome extension designed to enhance the user experience on some modeling pages by providing utility functions directly within the model view. This extension integrates seamlessly with the target platform, offering features such as quick messages, status indicators and user interface enhancements.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -72,9 +72,24 @@
     },
     "mangoAssistant": {
       "seeMore": "/en/mango-assistant"
+    },
+    "docucofi": {
+      "seeMore": "/en/docucofi"
     }
   },
   "ProjectDetails": {
+    "docucofi": {
+      "title": "Docucofi",
+      "desc": "DocuCofi is a web application that simplifies formal document generation for freelancers and small teams. Users select from a template catalog, fill in the required fields, and receive a downloadable PDF. It supports service invoice generation, multi-language support, and dark/light mode.",
+      "github": {
+        "label": "GitHub",
+        "link": "https://github.com/juanleon8581/docucofi"
+      },
+      "goIt": {
+        "label": "Visit",
+        "link": "https://docucofi.coficode.dev/"
+      }
+    },
     "mangoAssistant": {
       "title": "Mango",
       "desc": "A keyboard-driven TUI for running your shell command sequences — no more copy-pasting the same commands. Define macros (named sequences of shell commands) grouped by category, pick one from the TUI, and it runs with real-time output streaming. Macros that need input show a prompt dialog before running.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -103,15 +103,15 @@
       }
     },
     "scTools": {
-      "title": "ScTools",
-      "desc": "SCTools is a Chrome extension designed to enhance the user experience on some modeling pages by providing utility functions directly within the model view. This extension integrates seamlessly with the target platform, offering features such as quick messages, status indicators and user interface enhancements.",
+      "title": "Redna-Models",
+      "desc": "Redna-Models is a Chrome extension designed to enhance the user experience on modeling platforms by providing utility functions directly within the model view. This extension integrates seamlessly with the target platforms, offering features such as quick messages, status indicators, user interface enhancements, and built-in translation tools to communicate across language barriers.",
       "downloadButton": {
         "label": "Download LTS",
-        "link": "https://pub-001b6d146cb14cfcac56c049c5d435f1.r2.dev/sctools_LTS.zip"
+        "link": "https://www.estrellaswebcam.com/descargas"
       },
       "goIt": {
         "label": "Go",
-        "link": "https://github.com/webmodelcode/sctools"
+        "link": "https://www.estrellaswebcam.com/guides/extensiones/redna-models"
       }
     }
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -66,9 +66,24 @@
     "projectBtn": "Saber más",
     "scTools": {
       "seeMore": "/es/sctools"
+    },
+    "mangoAssistant": {
+      "seeMore": "/es/mango-assistant"
     }
   },
   "ProjectDetails": {
+    "mangoAssistant": {
+      "title": "Mango",
+      "desc": "Una TUI con navegación por teclado para ejecutar tus secuencias de comandos de shell — sin más copiar y pegar los mismos comandos. Define macros (secuencias de comandos nombradas) agrupadas por categoría, elige una desde la TUI y se ejecuta con salida en tiempo real. Las macros que necesitan entrada muestran un diálogo de parámetros antes de ejecutarse.",
+      "pypi": {
+        "label": "PyPI",
+        "link": "https://pypi.org/project/mango-tui/"
+      },
+      "goIt": {
+        "label": "GitHub",
+        "link": "https://github.com/juanleon8581/mango-assistant"
+      }
+    },
     "scTools": {
       "title": "ScTools",
       "desc": "SCTools es una extensión de Chrome diseñada para mejorar la experiencia del usuario en algunas paginas de modelage, proporcionando funciones de utilidad directamente dentro de la vista del modelo. Esta extensión se integra perfectamente con la plataforma objetivo, ofreciendo funciones como mensajes rápidos, indicadores de estado y mejoras en la interfaz de usuario.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -69,9 +69,24 @@
     },
     "mangoAssistant": {
       "seeMore": "/es/mango-assistant"
+    },
+    "docucofi": {
+      "seeMore": "/es/docucofi"
     }
   },
   "ProjectDetails": {
+    "docucofi": {
+      "title": "Docucofi",
+      "desc": "DocuCofi es una aplicación web que simplifica la generación de documentos formales para freelancers y equipos pequeños. Los usuarios seleccionan una plantilla, completan los campos requeridos y reciben un PDF listo para descargar. Soporta generación de facturas de servicio, múltiples idiomas y modo oscuro/claro.",
+      "github": {
+        "label": "GitHub",
+        "link": "https://github.com/juanleon8581/docucofi"
+      },
+      "goIt": {
+        "label": "Visitar",
+        "link": "https://docucofi.coficode.dev/"
+      }
+    },
     "mangoAssistant": {
       "title": "Mango",
       "desc": "Una TUI con navegación por teclado para ejecutar tus secuencias de comandos de shell — sin más copiar y pegar los mismos comandos. Define macros (secuencias de comandos nombradas) agrupadas por categoría, elige una desde la TUI y se ejecuta con salida en tiempo real. Las macros que necesitan entrada muestran un diálogo de parámetros antes de ejecutarse.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -100,15 +100,15 @@
       }
     },
     "scTools": {
-      "title": "ScTools",
-      "desc": "SCTools es una extensión de Chrome diseñada para mejorar la experiencia del usuario en algunas paginas de modelage, proporcionando funciones de utilidad directamente dentro de la vista del modelo. Esta extensión se integra perfectamente con la plataforma objetivo, ofreciendo funciones como mensajes rápidos, indicadores de estado y mejoras en la interfaz de usuario.",
+      "title": "Redna-Models",
+      "desc": "Redna-Models es una extensión de Chrome diseñada para mejorar la experiencia del usuario en plataformas de modelaje, proporcionando funciones de utilidad directamente dentro de la vista del modelo. Esta extensión se integra perfectamente con las plataformas objetivo, ofreciendo funciones como mensajes rápidos, indicadores de estado, mejoras en la interfaz de usuario y herramientas de traducción integradas para comunicarse superando la barrera del idioma.",
       "downloadButton": {
         "label": "Ultima version estable",
-        "link": "https://pub-001b6d146cb14cfcac56c049c5d435f1.r2.dev/sctools_LTS.zip"
+        "link": "https://www.estrellaswebcam.com/descargas"
       },
       "goIt": {
         "label": "Ir",
-        "link": "https://github.com/webmodelcode/sctools"
+        "link": "https://www.estrellaswebcam.com/guides/extensiones/redna-models"
       }
     }
   },

--- a/src/app/[locale]/docucofi/page.tsx
+++ b/src/app/[locale]/docucofi/page.tsx
@@ -1,0 +1,65 @@
+import { DetailProject } from '@/components/DetailProject';
+import type {
+  ProjectImageType,
+  ProjectBadgeType,
+  LinkButtonType,
+} from '@/components/DetailProject';
+import { NavBar } from '@/components/NavBar';
+import { Metadata } from 'next';
+import { useTranslations } from 'next-intl';
+
+export const metadata: Metadata = {
+  title: 'Docucofi',
+  description: 'Web application for formal document generation for freelancers and small teams',
+  keywords: ['documents', 'pdf', 'invoice', 'next.js', 'supabase', 'typescript'],
+  creator: 'Juan Pablo Leon Maya',
+  publisher: 'Juan Pablo Leon Maya',
+  alternates: {
+    languages: { en: 'en', es: 'es' },
+  },
+};
+
+const docucofiImages: ProjectImageType[] = [
+  {
+    src: 'https://pub-fda94ed7b1d0487db34447feefb77dbb.r2.dev/docucofi.png',
+    alt: 'Docucofi document generator',
+  },
+];
+
+const docucofiBadges: ProjectBadgeType[] = [
+  { label: 'Next.js', className: 'bg-[#000000] text-white' },
+  { label: 'TypeScript', className: 'bg-[#3178C6] text-white' },
+  { label: 'Supabase', className: 'bg-[#3ECF8E] text-black' },
+  { label: 'Tailwind CSS', className: 'bg-[#00BCFF] text-white' },
+  { label: 'React PDF', className: 'bg-[#EC5990] text-white' },
+  { label: 'Zod' },
+  { label: 'Zustand' },
+];
+
+export default function Page() {
+  const t = useTranslations('ProjectDetails');
+
+  const docucofiGithub: LinkButtonType = {
+    label: t('docucofi.github.label'),
+    link: t('docucofi.github.link'),
+  };
+
+  const docucofiGoIt: LinkButtonType = {
+    label: t('docucofi.goIt.label'),
+    link: t('docucofi.goIt.link'),
+  };
+
+  return (
+    <section>
+      <NavBar from="docucofi" />
+      <DetailProject
+        title={t('docucofi.title')}
+        description={t('docucofi.desc')}
+        badges={docucofiBadges}
+        images={docucofiImages}
+        github={docucofiGithub}
+        goIt={docucofiGoIt}
+      />
+    </section>
+  );
+}

--- a/src/app/[locale]/mango-assistant/page.tsx
+++ b/src/app/[locale]/mango-assistant/page.tsx
@@ -1,0 +1,61 @@
+import { DetailProject } from '@/components/DetailProject';
+import type {
+  ProjectImageType,
+  ProjectBadgeType,
+  LinkButtonType,
+} from '@/components/DetailProject';
+import { NavBar } from '@/components/NavBar';
+import { Metadata } from 'next';
+import { useTranslations } from 'next-intl';
+
+export const metadata: Metadata = {
+  title: 'mango',
+  description: 'Keyboard-driven TUI assistant for running shell command sequences',
+  keywords: ['tui', 'terminal', 'python', 'cli', 'textual', 'macros'],
+  creator: 'Juan Pablo Leon Maya',
+  publisher: 'Juan Pablo Leon Maya',
+  alternates: {
+    languages: { en: 'en', es: 'es' },
+  },
+};
+
+const mangoImages: ProjectImageType[] = [
+  {
+    src: 'https://pub-fda94ed7b1d0487db34447feefb77dbb.r2.dev/mango-preview.png',
+    alt: 'mango TUI main view',
+  },
+];
+
+const mangoBadges: ProjectBadgeType[] = [
+  { label: 'Python', className: 'bg-[#3776AB] text-white' },
+  { label: 'Textual', className: 'bg-[#004578] text-white' },
+  { label: 'PyPI', className: 'bg-[#006DAD] text-white' },
+];
+
+export default function Page() {
+  const t = useTranslations('ProjectDetails');
+
+  const mangoDownload: LinkButtonType = {
+    label: t('mangoAssistant.pypi.label'),
+    link: t('mangoAssistant.pypi.link'),
+  };
+
+  const mangoGoIt: LinkButtonType = {
+    label: t('mangoAssistant.goIt.label'),
+    link: t('mangoAssistant.goIt.link'),
+  };
+
+  return (
+    <section>
+      <NavBar from="mango-assistant" />
+      <DetailProject
+        title={t('mangoAssistant.title')}
+        description={t('mangoAssistant.desc')}
+        badges={mangoBadges}
+        images={mangoImages}
+        download={mangoDownload}
+        goIt={mangoGoIt}
+      />
+    </section>
+  );
+}

--- a/src/app/[locale]/sctools/page.tsx
+++ b/src/app/[locale]/sctools/page.tsx
@@ -9,9 +9,9 @@ import { Metadata } from 'next';
 import { useTranslations } from 'next-intl';
 
 export const metadata: Metadata = {
-  title: 'ScTools',
-  description: 'Serverless computing tools',
-  keywords: ['serverless', 'sc', 'tools', 'development'],
+  title: 'Redna-Models',
+  description: 'Chrome extension that enhances user experience on modeling platforms with utility functions and translation features',
+  keywords: ['chrome extension', 'redna', 'models', 'translation', 'webcam', 'modeling'],
   creator: 'Juan Pablo Leon Maya',
   publisher: 'Juan Pablo Leon Maya',
   alternates: {
@@ -43,7 +43,7 @@ const scToolsBadges: ProjectBadgeType[] = [
   { label: 'TailwindCSS', className: 'bg-[#00BCFF] text-white' },
   { label: 'Vite', className: 'bg-[#FFC820] text-white' },
   { label: 'Vitest', className: 'bg-[#729B1B] text-white' },
-  { label: 'Crxjs' },
+  { label: 'WXT' },
   { label: 'ShadCn', className: 'bg-white text-black' },
 ];
 

--- a/src/components/DetailProject.tsx
+++ b/src/components/DetailProject.tsx
@@ -13,7 +13,7 @@ import {
 import { Badge } from './ui/badge';
 import { cn } from '@/lib/utils';
 import { Button } from './ui/button';
-import { Download, ExternalLink } from 'lucide-react';
+import { Code2, Download, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
 
 export type ProjectImageType = {
@@ -35,6 +35,7 @@ interface DetailProjectProps {
   images: ProjectImageType[];
   download?: LinkButtonType;
   goIt?: LinkButtonType;
+  github?: LinkButtonType;
   projectVersion?: string;
 }
 
@@ -45,6 +46,7 @@ export const DetailProject = ({
   images,
   download,
   goIt,
+  github,
   projectVersion,
 }: DetailProjectProps) => {
   return (
@@ -107,6 +109,14 @@ export const DetailProject = ({
                     </span>
                   )}
                   <Download />
+                </Button>
+              </Link>
+            )}
+            {github && (
+              <Link href={github.link} target="_blank">
+                <Button variant={'outline'}>
+                  <span>{github.label}</span>
+                  <Code2 />
                 </Button>
               </Link>
             )}

--- a/src/components/MyProjects.tsx
+++ b/src/components/MyProjects.tsx
@@ -29,6 +29,14 @@ export const MyProjects = () => {
       seeMoreUrl: t('mangoAssistant.seeMore'),
     },
     {
+      projectName: 'Docucofi',
+      imgUrl:
+        'https://pub-fda94ed7b1d0487db34447feefb77dbb.r2.dev/docucofi.png',
+      alt: 'Docucofi - Document Generator',
+      url: 'https://docucofi.coficode.dev/',
+      seeMoreUrl: t('docucofi.seeMore'),
+    },
+    {
       projectName: 'Espíritu Guerrero',
       imgUrl:
         'https://pub-fda94ed7b1d0487db34447feefb77dbb.r2.dev/espiritu-thumbnail-4-3.png',

--- a/src/components/MyProjects.tsx
+++ b/src/components/MyProjects.tsx
@@ -22,6 +22,13 @@ export const MyProjects = () => {
       seeMoreUrl: t('scTools.seeMore'),
     },
     {
+      projectName: 'mango',
+      imgUrl: 'https://pub-fda94ed7b1d0487db34447feefb77dbb.r2.dev/mango-preview.png',
+      alt: 'mango TUI assistant',
+      url: 'https://github.com/juanleon8581/mango-assistant',
+      seeMoreUrl: t('mangoAssistant.seeMore'),
+    },
+    {
       projectName: 'Espíritu Guerrero',
       imgUrl:
         'https://pub-fda94ed7b1d0487db34447feefb77dbb.r2.dev/espiritu-thumbnail-4-3.png',

--- a/src/components/MyProjects.tsx
+++ b/src/components/MyProjects.tsx
@@ -14,11 +14,11 @@ export const MyProjects = () => {
   const t = useTranslations('MyProjects');
   const galleryItems: GalleryItem[] = [
     {
-      projectName: 'ScTools',
+      projectName: 'Redna-Models',
       imgUrl:
-        'https://pub-fda94ed7b1d0487db34447feefb77dbb.r2.dev/sctools-4-3.png',
-      alt: 'Web Model Tools',
-      url: 'https://github.com/webmodelcode/sctools',
+        'https://pub-fda94ed7b1d0487db34447feefb77dbb.r2.dev/redna-models-icon-2.webp',
+      alt: 'Redna-Models',
+      url: 'https://www.estrellaswebcam.com/guides/extensiones/redna-models',
       seeMoreUrl: t('scTools.seeMore'),
     },
     {

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -19,7 +19,7 @@ interface MenuItem {
   href: string;
 }
 
-type FromProp = 'index' | 'contact' | 'sctools';
+type FromProp = 'index' | 'contact' | 'sctools' | 'mango-assistant';
 
 export const NavBar = ({ from = 'index' }: { from?: FromProp }) => {
   const t = useTranslations('Navbar');

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -19,7 +19,7 @@ interface MenuItem {
   href: string;
 }
 
-type FromProp = 'index' | 'contact' | 'sctools' | 'mango-assistant';
+type FromProp = 'index' | 'contact' | 'sctools' | 'mango-assistant' | 'docucofi';
 
 export const NavBar = ({ from = 'index' }: { from?: FromProp }) => {
   const t = useTranslations('Navbar');

--- a/src/components/ProjectThumbnail.tsx
+++ b/src/components/ProjectThumbnail.tsx
@@ -75,7 +75,7 @@ export const ProjectThumbnail = ({ item }: ProjectThumbnailProp) => {
           <Image
             src={imgUrl}
             alt={alt}
-            className="rounded-md object-cover mx-auto w-full"
+            className="rounded-md object-cover object-center mx-auto w-full h-full"
             height={300}
             width={400}
           />


### PR DESCRIPTION
## Release 1.4.0

### Overview
This release adds three new projects to the portfolio: mango-assistant, Docucofi, and Redna-Models (formerly ScTools). It also includes a major Tailwind CSS v4 upgrade, full dependency refresh, and improved project detail components with GitHub link support.

### Changes

### Added
- Add CLAUDE.md with project guidance and architecture documentation (4f5b237)
- Add mango-assistant project to portfolio (83eecc8)
- Add Docucofi project page and update project details component to support GitHub links (e73116a)
- Rename ScTools to Redna-Models, update project metadata, and migrate documentation links (864d964)

### Changed
- Upgrade Tailwind CSS to v4 (30f4920)
- Bump all dependencies to latest versions (fa6524d)
- Exclude test files from TypeScript compilation (0742c17)
- Specify package manager version in package.json (5bacc1d)
- Initialize workspace packages array in pnpm-workspace.yaml (50a5515)

### Checklist
- [ ] CHANGELOG reviewed
- [ ] Tests passing
- [ ] No breaking changes undocumented